### PR TITLE
Use ruby 2.2.2 on heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+ruby '2.2.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.1'


### PR DESCRIPTION
heroku上でRubyの最新バージョンである2.2.2を使えるようにします
